### PR TITLE
Configure CircleCI 🔄

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.9
+    working_directory: ~/projectread
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements.txt
+      - run:
+          name: Test
+          command: ./manage.py test
+      - run:
+          name: Lint
+          command: black --check .


### PR DESCRIPTION
Adds `.circleci/config.yml`! This gets CircleCI to run checks for our unit tests and linter.