### PR TITLE
Configure enrolments app in settings.py

### DIFF
--- a/projectread/settings.py
+++ b/projectread/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "accounts.apps.AccountsConfig",
+    "enrolments.apps.EnrolmentsConfig",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
forgot to add this line to settings.py! :blobsweat:

this is needed or else Django won't know the app exists (oops)