### PR TITLE
Add number of children to FamilySerializer

### DIFF
--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -1,11 +1,12 @@
 from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
-from .models import Family, FamilyInfo, ChildInfo
+from .models import Family, Student, FamilyInfo, ChildInfo
 
 
 class FamilySerializer(serializers.HyperlinkedModelSerializer):
     first_name = SerializerMethodField()
     last_name = SerializerMethodField()
+    num_children = SerializerMethodField()
 
     class Meta:
         model = Family
@@ -17,10 +18,13 @@ class FamilySerializer(serializers.HyperlinkedModelSerializer):
             "phone_number",
             "address",
             "preferred_comms",
+            "num_children",
         ]
-    
+
     def get_num_children(self, obj):
-        return Student.objects.filter(family=obj.id, attendee_type=Student.ATTENDEE_CHOICES.CHILD).count()
+        return Student.objects.filter(
+            family=obj.id, attendee_type=Student.CHILD
+        ).count()
 
     def get_first_name(self, obj):
         return obj.parent.first_name if obj.parent else ""

--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -18,6 +18,9 @@ class FamilySerializer(serializers.HyperlinkedModelSerializer):
             "address",
             "preferred_comms",
         ]
+    
+    def get_num_children(self, obj):
+        return Student.objects.filter(family=obj.id, attendee_type=Student.ATTENDEE_CHOICES.CHILD).count()
 
     def get_first_name(self, obj):
         return obj.parent.first_name if obj.parent else ""

--- a/registration/tests/test_serializers.py
+++ b/registration/tests/test_serializers.py
@@ -6,16 +6,30 @@ from registration.serializers import FamilySerializer
 
 class SerializersTestCase(APITestCase):
     def setUp(self):
-        self.parent = Student.objects.create(
-            first_name="Merlin", last_name="Fish", attendee_type="Parent"
+        self.parent1 = Student.objects.create(
+            first_name="Merlin", last_name="Fish", attendee_type=Student.PARENT
         )
+
+        self.parent2 = Student.objects.create(
+            first_name="Gandalf", last_name="Whale", attendee_type=Student.PARENT
+        )
+
         self.family = Family.objects.create(
-            parent=self.parent,
+            parent=self.parent2,
+            email="justkeepswimming@ocean.com",
+            phone_number="123456789",
+            address="1 Django Boulevard",
+            preferred_comms="Shark Tune",
+        )
+
+        self.family_without_children = Family.objects.create(
+            parent=self.parent1,
             email="justkeepswimming@ocean.com",
             phone_number="123456789",
             address="42 Wallaby Way",
             preferred_comms="Whale Song",
         )
+
         self.family_without_parent = Family.objects.create(
             email="justkeepswimming@ocean.com",
             phone_number="123456789",
@@ -23,12 +37,41 @@ class SerializersTestCase(APITestCase):
             preferred_comms="Dolphin Whistle",
         )
 
+        self.child1 = Student.objects.create(
+            first_name="Albus",
+            last_name="Whale",
+            attendee_type=Student.CHILD,
+            family=self.family,
+        )
+
+        self.child2 = Student.objects.create(
+            first_name="Lily",
+            last_name="Whale",
+            attendee_type=Student.CHILD,
+            family=self.family,
+        )
+
+        self.child3 = Student.objects.create(
+            first_name="Harry",
+            last_name="Tuna",
+            attendee_type=Student.CHILD,
+            family=self.family_without_parent,
+        )
+
     def test_family_serializer_parent_name(self):
-        data = FamilySerializer(self.family).data
-        self.assertEqual(data.get("first_name"), self.parent.first_name)
-        self.assertEqual(data.get("last_name"), self.parent.last_name)
+        data = FamilySerializer(self.family_without_children).data
+        self.assertEqual(data.get("first_name"), self.parent1.first_name)
+        self.assertEqual(data.get("last_name"), self.parent1.last_name)
 
     def test_family_serializer_parent_name_none(self):
         data = FamilySerializer(self.family_without_parent).data
         self.assertEqual(data.get("first_name"), "")
         self.assertEqual(data.get("last_name"), "")
+
+    def test_family_serializer_children(self):
+        data = FamilySerializer(self.family).data
+        self.assertEqual(data.get("num_children"), 2)
+
+    def test_family_serializer_children_none(self):
+        data = FamilySerializer(self.family_without_children).data
+        self.assertEqual(data.get("num_children"), 0)


### PR DESCRIPTION
### Notion ticket link

[Add number of children to FamilySerializer](https://www.notion.so/uwblueprintexecs/9cb454262ed84c6299c0682c23f92ec5?v=1076bd30711a4a01838becee05f8b5a3&p=0ba3aace68744d30a1f861901325ebbc)

### Implementation description

- added `num_children` to FamilySerializer
- updated tests in `test_serializers.py`

### Steps to test

1. `python manage.py test`

### What should reviewers focus on?

- correctness & test coverage

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
