### PR TITLE
Add frontend URL to CORS allowed origins

### DIFF
--- a/projectread/settings.py
+++ b/projectread/settings.py
@@ -34,6 +34,10 @@ ALLOWED_HOSTS = [] if DEBUG else ["project-read-backend.herokuapp.com"]
 
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000"] if DEBUG else []
 
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"https:\/\/(deploy\-preview\-[0-9]+\-\-)?getsetlearn\.netlify\.com:8443$"
+]
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Deploy frontend](https://www.notion.so/uwblueprintexecs/9cb454262ed84c6299c0682c23f92ec5?v=1076bd30711a4a01838becee05f8b5a3&p=c8a2ae9ece804381972b0851177ce478)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- adds the frontend URL to CORS_ALLOWED_ORIGINS 😄 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. currently deployed to Heroku and the frontend works! check out http://getsetlearn.herokuapp.com/ (ensure your firebase ID is set in the backend)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- N/A

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
