### PR TITLE
Add validator for enrolments per session

### DIFF
--- a/enrolments/tests/test_validators.py
+++ b/enrolments/tests/test_validators.py
@@ -6,6 +6,7 @@ from enrolments.validators import (
     validate_attendance,
     validate_schema,
     validate_class_in_session,
+    validate_enrolment_in_session,
     validate_enrolment,
     validate_fields,
     validate_students_in_enrolment,
@@ -51,6 +52,73 @@ class EnrolmentValidatorTestCase(TestCase):
             self.class_in_session,
             session_other,
         )
+
+    def test_validate_enrolment_in_session(self):
+        session1 = Session.objects.create(season=Session.SPRING, year="2020")
+        session2 = Session.objects.create(season=Session.FALL, year="2019")
+        class1_in_session1 = Class.objects.create(
+            name="Class 1 in Session 1",
+            session=session1,
+            facilitator=self.user,
+            attendance={},
+        )
+        class2_in_session1 = Class.objects.create(
+            name="Class 2 in Session 1",
+            session=session1,
+            facilitator=self.user,
+            attendance={},
+        )
+        class1_in_session2 = Class.objects.create(
+            name="Class 1 in Session 2",
+            session=session2,
+            facilitator=self.user,
+            attendance={},
+        )
+        family1 = Family.objects.create(
+            email="fam1@test.com",
+            cell_number="123456789",
+            address="1 Fam St",
+            preferred_comms="email",
+        )
+        family2 = Family.objects.create(
+            email="fam2@test.com",
+            cell_number="123456789",
+            address="2 Fam St",
+            preferred_comms="email",
+        )
+        enrolment1_for_family1 = Enrolment.objects.create(
+            active=True,
+            family=family1,
+            session=session1,
+            enrolled_class=class1_in_session1,
+        )
+        enrolment2_for_family1 = Enrolment.objects.create(
+            active=False,
+            family=family1,
+            session=session2,
+            enrolled_class=class1_in_session2,
+        )
+        enrolment1_for_family2 = Enrolment.objects.create(
+            active=True,
+            family=family2,
+            session=session1,
+            enrolled_class=class1_in_session1,
+        )
+        duplicate_enrolment = Enrolment.objects.create(
+            active=True,
+            family=family1,
+            session=session1,
+            enrolled_class=class2_in_session1,
+        )
+
+        # Duplicate class enrolments for family1 in session1
+        self.assertRaises(
+            ValidationError, validate_enrolment_in_session, session1, family1
+        )
+        # Many families can enrol in a session
+        self.assertIsNone(validate_enrolment_in_session(session1, family2))
+        # A family can have multiple enrolments across different sessions
+        self.assertIsNone(validate_enrolment_in_session(session2, family2))
 
     @patch("enrolments.validators.validate_class_in_session")
     def test_validate_enrolments(self, mock_validate):

--- a/enrolments/tests/test_validators.py
+++ b/enrolments/tests/test_validators.py
@@ -24,7 +24,7 @@ class EnrolmentValidatorTestCase(TestCase):
             address="1 Fam Ave",
             preferred_comms="email",
         )
-        self.session = Session.objects.create(season=Session.FALL, year="2020")
+        self.session = Session.objects.create(season=Session.FALL, year="2019")
         self.class_in_session = Class.objects.create(
             name="Class in session",
             session=self.session,
@@ -54,8 +54,8 @@ class EnrolmentValidatorTestCase(TestCase):
         )
 
     def test_validate_enrolment_in_session(self):
-        session1 = Session.objects.create(season=Session.SPRING, year="2020")
-        session2 = Session.objects.create(season=Session.FALL, year="2019")
+        session1 = Session.objects.create(season=Session.SPRING, year="2019")
+        session2 = self.session
         class1_in_session1 = Class.objects.create(
             name="Class 1 in Session 1",
             session=session1,
@@ -68,18 +68,8 @@ class EnrolmentValidatorTestCase(TestCase):
             facilitator=self.user,
             attendance={},
         )
-        class1_in_session2 = Class.objects.create(
-            name="Class 1 in Session 2",
-            session=session2,
-            facilitator=self.user,
-            attendance={},
-        )
-        family1 = Family.objects.create(
-            email="fam1@test.com",
-            cell_number="123456789",
-            address="1 Fam St",
-            preferred_comms="email",
-        )
+        class1_in_session2 = self.class_in_session
+        family1 = self.family
         family2 = Family.objects.create(
             email="fam2@test.com",
             cell_number="123456789",

--- a/enrolments/validators.py
+++ b/enrolments/validators.py
@@ -26,10 +26,10 @@ def validate_class_in_session(class_obj, session):
 
 def validate_enrolment_in_session(session, family):
     Enrolment = apps.get_model("enrolments", "Enrolment")
-    family_enrolments_per_session = Enrolment.objects.filter(
+    family_enrolments_in_session = Enrolment.objects.filter(
         session=session, family=family
     )
-    if len(family_enrolments_per_session) > 1:
+    if len(family_enrolments_in_session) > 1:
         raise ValidationError(
             f"Family with ID {family.id} has multiple enrolments per Session with ID {session.id}"
         )

--- a/enrolments/validators.py
+++ b/enrolments/validators.py
@@ -24,21 +24,21 @@ def validate_class_in_session(class_obj, session):
         )
 
 
-def validate_enrolment(enrolment):
-    validate_class_in_session(enrolment.preferred_class, enrolment.session)
-    validate_class_in_session(enrolment.enrolled_class, enrolment.session)
-
-
-def validate_class_in_session(class_obj, session):
-    if class_obj.session != session:
+def validate_enrolment_in_session(session, family):
+    Enrolment = apps.get_model("enrolments", "Enrolment")
+    family_enrolments_per_session = Enrolment.objects.filter(
+        session=session, family=family
+    )
+    if len(family_enrolments_per_session) > 1:
         raise ValidationError(
-            f"Class {class_obj.name} is not in session with ID {session.id}"
+            f"Family with ID {family.id} has multiple enrolments per Session with ID {session.id}"
         )
 
 
 def validate_enrolment(enrolment):
     validate_class_in_session(enrolment.preferred_class, enrolment.session)
     validate_class_in_session(enrolment.enrolled_class, enrolment.session)
+    validate_enrolment_in_session(enrolment.session, enrolment.family)
 
 
 def validate_attendance(class_obj):


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Validate that a family only has one enrolment per session](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=6ed1d59a4ed4416fa90b2a58dba8ac72)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Updated [this validator](https://github.com/uwblueprint/project-read-backend/blob/8e190c7b28ff336e48b1cd627c967bc452228d75/enrolments/validators.py#L27) to ensure that a family only has one enrolment per session
- Removed duplicate validators in that file^
- Ensured that the following tests cases still hold:
   - a family can be enrolled in multiple different sessions
   - many families can be enrolled in a given session

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. python manage test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Test coverage

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
