### PR TITLE
Order GET /sessions by descending start date

### DIFF
--- a/enrolments/tests/views/test_session.py
+++ b/enrolments/tests/views/test_session.py
@@ -1,3 +1,4 @@
+from datetime import date
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -10,8 +11,15 @@ from enrolments.serializers import SessionSerializer, SessionDetailSerializer
 class SessionTestCase(APITestCase):
     def setUp(self):
         self.user = User.objects.create(email="user@staff.com")
-        self.session1 = Session.objects.create(season=Session.SPRING, year=2021)
-        self.session2 = Session.objects.create(season=Session.SUMMER, year=2021)
+        self.session = Session.objects.create(
+            season=Session.SUMMER, year=2021, start_date=date(2021, 1, 1)
+        )
+        self.older_session = Session.objects.create(
+            season=Session.SPRING, year=2021, start_date=date(2020, 1, 1)
+        )
+        self.session_no_start_date = Session.objects.create(
+            season=Session.SUMMER, year=2021, start_date=None
+        )
 
     def test_get_all_sessions(self):
         url = reverse("session-list")
@@ -20,25 +28,28 @@ class SessionTestCase(APITestCase):
         payload = response.json()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # sessions should be ordered by descending start date, with nulls last
         self.assertEqual(
             payload,
             [
-                SessionSerializer(self.session1).data,
-                SessionSerializer(self.session2).data,
+                SessionSerializer(self.session).data,
+                SessionSerializer(self.older_session).data,
+                SessionSerializer(self.session_no_start_date).data,
             ],
         )
 
     def test_get_session(self):
-        url = reverse("session-detail", args=[self.session1.id])
+        url = reverse("session-detail", args=[self.session.id])
         self.client.force_authenticate(self.user)
         response = self.client.get(url)
         payload = response.json()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(payload, SessionDetailSerializer(self.session1).data)
+        self.assertEqual(payload, SessionDetailSerializer(self.session).data)
 
     def test_method_not_allowed(self):
-        url = reverse("session-detail", args=[self.session1.id])
+        url = reverse("session-detail", args=[self.session.id])
         self.client.force_authenticate(self.user)
 
         response = self.client.post(url)
@@ -62,7 +73,7 @@ class SessionTestCase(APITestCase):
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        url = reverse("session-detail", args=[self.session1.id])
+        url = reverse("session-detail", args=[self.session.id])
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/enrolments/views.py
+++ b/enrolments/views.py
@@ -1,3 +1,4 @@
+from django.db.models import F
 from rest_framework import mixins, permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -16,7 +17,8 @@ class SessionViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
 ):
-    queryset = Session.objects.all()
+    queryset = Session.objects.all().order_by(F("start_date").desc(nulls_last=True))
+
     serializer_class = SessionSerializer
     http_method_names = [
         "get",

--- a/enrolments/views.py
+++ b/enrolments/views.py
@@ -18,7 +18,6 @@ class SessionViewSet(
     mixins.RetrieveModelMixin,
 ):
     queryset = Session.objects.all().order_by(F("start_date").desc(nulls_last=True))
-
     serializer_class = SessionSerializer
     http_method_names = [
         "get",


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Order GET /sessions by descending start date](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=f8608b78745b412499e05bcfd55c8da2)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- updated the queryset on the `SessionViewSet` to order sessions by descending start date, with null start dates last
- updated test cases

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. `python manage.py test`

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- squeaky clean code 🧼 

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
