### PR TITLE
add enrolments detail endpoint and allow PUT requests

### DIFF
--- a/enrolments/serializers.py
+++ b/enrolments/serializers.py
@@ -1,5 +1,4 @@
-from django.db.models import query
-from rest_framework import response, serializers
+from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 from registration.serializers import FamilySerializer
 from .models import Session, Class, Enrolment

--- a/enrolments/tests/test_serializers.py
+++ b/enrolments/tests/test_serializers.py
@@ -186,15 +186,26 @@ class EnrolmentSerializerTestCase(TestCase):
             year=2021,
             start_date=date(2021, 5, 15),
         )
-        self.preferred_class = Class.objects.create(
-            name="Preferred Class",
+        self.other_session = Session.objects.create(
+            season="Fall",
+            year=2021,
+            start_date=date(2021, 5, 15),
+        )
+        self.class1 = Class.objects.create(
+            name="Tuesday & Saturday",
             session_id=self.session.id,
             facilitator_id=None,
             attendance=[],
         )
-        self.enrolled_class = Class.objects.create(
-            name="Enrolled Class",
+        self.class2 = Class.objects.create(
+            name="Wednesday & Thursday",
             session_id=self.session.id,
+            facilitator_id=None,
+            attendance=[],
+        )
+        self.class_not_in_session = Class.objects.create(
+            name="Wednesday & Thursday",
+            session_id=self.other_session.id,
             facilitator_id=None,
             attendance=[],
         )
@@ -202,10 +213,21 @@ class EnrolmentSerializerTestCase(TestCase):
             active=False,
             family=self.family,
             session=self.session,
-            preferred_class=self.preferred_class,
-            enrolled_class=self.enrolled_class,
+            preferred_class=self.class1,
+            enrolled_class=self.class2,
             status=Enrolment.REGISTERED,
         )
+        self.update_request = {
+            "id": self.enrolment.id,
+            "session": {
+                "id": self.session.id,
+                "season": self.session.season,
+                "year": self.session.year,
+            },
+            "preferred_class": {"id": self.class2.id, "name": self.class2.name},
+            "enrolled_class": {"id": self.class1.id, "name": self.class1.name},
+            "status": Enrolment.CLASS_ALLOCATED,
+        }
 
     def test_enrolment_serializer(self):
         self.assertEqual(
@@ -217,14 +239,37 @@ class EnrolmentSerializerTestCase(TestCase):
                     "year": self.session.year,
                 },
                 "preferred_class": {
-                    "id": self.preferred_class.id,
-                    "name": self.preferred_class.name,
+                    "id": self.class1.id,
+                    "name": self.class1.name,
                 },
                 "enrolled_class": {
-                    "id": self.enrolled_class.id,
-                    "name": self.enrolled_class.name,
+                    "id": self.class2.id,
+                    "name": self.class2.name,
                 },
                 "status": self.enrolment.status,
             },
             EnrolmentSerializer(self.enrolment).data,
         )
+
+    def test_enrolment_update(self):
+        serializer = EnrolmentSerializer(data=self.update_request)
+        self.assertTrue(serializer.is_valid())
+        updated_enrolment = EnrolmentSerializer.update(
+            self, self.enrolment, self.update_request
+        )
+        self.assertEqual(self.enrolment, updated_enrolment)
+
+    def test_enrolment_update_read_only_session(self):
+        data = dict(self.update_request)
+        data["session"]["year"] += 1
+        serializer = EnrolmentSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        updated_enrolment = EnrolmentSerializer.update(self, self.enrolment, data)
+        self.assertEqual(self.enrolment, updated_enrolment)
+
+    def test_enrolment_update__invalid_class(self):
+        data = dict(self.update_request)
+        data["preferred_class"]["id"] = self.class_not_in_session.id
+        data["preferred_class"]["name"] = self.class_not_in_session.name
+        serializer = EnrolmentSerializer(data=data)
+        self.assertFalse(serializer.is_valid())

--- a/enrolments/tests/test_serializers.py
+++ b/enrolments/tests/test_serializers.py
@@ -250,7 +250,6 @@ class EnrolmentSerializerTestCase(TestCase):
     def test_enrolment_update(self):
         serializer = EnrolmentSerializer(data=self.update_request)
         self.assertTrue(serializer.is_valid())
-        serializer.save()
 
     def test_enrolment_update__read_only_session(self):
         data = dict(self.update_request)

--- a/enrolments/tests/test_serializers.py
+++ b/enrolments/tests/test_serializers.py
@@ -248,17 +248,19 @@ class EnrolmentSerializerTestCase(TestCase):
         )
 
     def test_enrolment_update(self):
-        serializer = EnrolmentSerializer(data=self.update_request)
+        serializer = EnrolmentSerializer(self.enrolment, data=self.update_request)
         self.assertTrue(serializer.is_valid())
 
     def test_enrolment_update__read_only_session(self):
         data = dict(self.update_request)
         data["session"] = self.other_session.id
-        serializer = EnrolmentSerializer(data=data)
-        self.assertFalse(serializer.is_valid())
+        serializer = EnrolmentSerializer(self.enrolment, data=data)
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+        self.assertEqual(self.enrolment.session, self.session)
 
     def test_enrolment_update__invalid_class(self):
         data = dict(self.update_request)
         data["preferred_class"] = self.class_not_in_session.id
-        serializer = EnrolmentSerializer(data=data)
+        serializer = EnrolmentSerializer(self.enrolment, data=data)
         self.assertFalse(serializer.is_valid())

--- a/enrolments/tests/test_serializers.py
+++ b/enrolments/tests/test_serializers.py
@@ -219,13 +219,9 @@ class EnrolmentSerializerTestCase(TestCase):
         )
         self.update_request = {
             "id": self.enrolment.id,
-            "session": {
-                "id": self.session.id,
-                "season": self.session.season,
-                "year": self.session.year,
-            },
-            "preferred_class": {"id": self.class2.id, "name": self.class2.name},
-            "enrolled_class": {"id": self.class1.id, "name": self.class1.name},
+            "session": self.session.id,
+            "preferred_class": self.class2.id,
+            "enrolled_class": self.class1.id,
             "status": Enrolment.CLASS_ALLOCATED,
         }
 
@@ -254,22 +250,16 @@ class EnrolmentSerializerTestCase(TestCase):
     def test_enrolment_update(self):
         serializer = EnrolmentSerializer(data=self.update_request)
         self.assertTrue(serializer.is_valid())
-        updated_enrolment = EnrolmentSerializer.update(
-            self, self.enrolment, self.update_request
-        )
-        self.assertEqual(self.enrolment, updated_enrolment)
+        serializer.save()
 
-    def test_enrolment_update_read_only_session(self):
+    def test_enrolment_update__read_only_session(self):
         data = dict(self.update_request)
-        data["session"]["year"] += 1
+        data["session"] = self.other_session.id
         serializer = EnrolmentSerializer(data=data)
-        self.assertTrue(serializer.is_valid())
-        updated_enrolment = EnrolmentSerializer.update(self, self.enrolment, data)
-        self.assertEqual(self.enrolment, updated_enrolment)
+        self.assertFalse(serializer.is_valid())
 
     def test_enrolment_update__invalid_class(self):
         data = dict(self.update_request)
-        data["preferred_class"]["id"] = self.class_not_in_session.id
-        data["preferred_class"]["name"] = self.class_not_in_session.name
+        data["preferred_class"] = self.class_not_in_session.id
         serializer = EnrolmentSerializer(data=data)
         self.assertFalse(serializer.is_valid())

--- a/enrolments/tests/views/test_enrolments.py
+++ b/enrolments/tests/views/test_enrolments.py
@@ -47,20 +47,14 @@ class EnrolmentsTestCase(APITestCase):
         self.client.force_authenticate(self.user)
         request = {
             "id": self.enrolment.id,
-            "session": {
-                "id": self.session.id,
-                "season": self.session.season,
-                "year": self.session.year,
-            },
-            "preferred_class": {"id": self.class2.id, "name": self.class2.name},
-            "enrolled_class": {"id": self.class2.id, "name": self.class2.name},
+            "session": self.session.id,
+            "preferred_class": self.class2.id,
+            "enrolled_class": self.class2.id,
             "status": Enrolment.CLASS_ALLOCATED,
         }
         response = self.client.put(url, request, format="json")
-        payload = response.json()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(request, payload)
 
     def test_method_not_allowed(self):
         self.client.force_authenticate(self.user)

--- a/enrolments/urls.py
+++ b/enrolments/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
-from .views import SessionViewSet, ClassViewSet
+from .views import EnrolmentViewSet, SessionViewSet, ClassViewSet
 
 router = DefaultRouter()
 router.register(r"sessions", SessionViewSet)
 router.register(r"classes", ClassViewSet)
+router.register(r"enrolments", EnrolmentViewSet)
 
 urlpatterns = [path("", include(router.urls))]

--- a/enrolments/views.py
+++ b/enrolments/views.py
@@ -3,11 +3,12 @@ from rest_framework import mixins, permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from .models import Session, Class
+from .models import Enrolment, Session, Class
 from .serializers import (
     SessionListSerializer,
     SessionDetailSerializer,
     ClassDetailSerializer,
+    EnrolmentSerializer,
 )
 
 
@@ -36,5 +37,14 @@ class ClassViewSet(
     serializer_class = ClassDetailSerializer
     http_method_names = [
         "get",
+    ]
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class EnrolmentViewSet(viewsets.GenericViewSet, mixins.UpdateModelMixin):
+    queryset = Enrolment.objects.all()
+    serializer_class = EnrolmentSerializer
+    http_method_names = [
+        "put",
     ]
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Edit status, enrolled class, preferred class](https://www.notion.so/uwblueprintexecs/Edit-status-enrolled-class-preferred-class-60db38ca6390432ab42cfbe3cbf1137a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Implemented PUT endpoint for `enrolments/{id}`
- added tests on the view and serializer levels

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test
- Automated testing
  - `./manage.py test`

- Manual testing
  1. Load initial data
  2. Go to `enrolments/{id}`
  3. Sent a PUT request 
  Tip: you can enable GET requests by adding `mixins.RetrieveModelMixin` to the EnrolmentViewSet (line 44 of `enrolments/views.py`) and adding "get" to the `http_method_names` list (line 47). This will let you see the PUT response and request on your browser.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Test cases. I'm mostly wondering if there's another way I should be writing the serializer tests.

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
