### PR TITLE
Return families' enrolments in the requested session/class

### DIFF
--- a/enrolments/admin.py
+++ b/enrolments/admin.py
@@ -42,15 +42,27 @@ class EnrolmentAdmin(admin.ModelAdmin):
         "family",
         "session",
         "status",
-        "created_at",
-        "updated_at",
         "preferred_class",
         "enrolled_class",
+        "created_at",
+        "updated_at",
     )
 
     ordering = ("-id",)
 
-    search_fields = ("family__id", "family__email", "enrolled_class__name")
+    search_fields = (
+        "family__id",
+        "family__email",
+        "family__parent__first_name",
+        "family__parent__last_name",
+        "enrolled_class__name",
+        "preferred_class__name",
+    )
+
+    list_filter = (
+        "session",
+        "status",
+    )
 
 
 admin.site.register(Session, SessionAdmin)

--- a/enrolments/serializers.py
+++ b/enrolments/serializers.py
@@ -44,7 +44,13 @@ class SessionDetailSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_families(self, obj):
         return [
-            FamilySerializer(enrolment.family, context={"request": None}).data
+            FamilySerializer(
+                enrolment.family,
+                context={
+                    "request": self.context.get("request"),
+                    "enrolment": EnrolmentSerializer(enrolment).data,
+                },
+            ).data
             for enrolment in obj.enrolments.filter(active=True)
         ]
 
@@ -62,12 +68,18 @@ class ClassDetailSerializer(serializers.HyperlinkedModelSerializer):
         ]
 
     def get_families(self, obj):
-        e_set = Enrolment.objects.filter(enrolled_class=obj, active=True)
+        request = self.context.get("request")
         return [
             FamilySerializer(
-                enrolment.family, read_only=True, context={"request": None}
+                enrolment.family,
+                context={
+                    "request": request,
+                    "enrolment": EnrolmentSerializer(
+                        enrolment, context={"request": request}
+                    ).data,
+                },
             ).data
-            for enrolment in e_set
+            for enrolment in obj.enrolments.filter(active=True)
         ]
 
 
@@ -88,6 +100,7 @@ class EnrolmentSerializer(serializers.HyperlinkedModelSerializer):
             "preferred_class",
             "enrolled_class",
             "status",
+            "students",
         ]
 
     def to_representation(self, instance):

--- a/enrolments/tests/test_serializers.py
+++ b/enrolments/tests/test_serializers.py
@@ -53,8 +53,18 @@ class SessionDetailSerializerTestCase(TestCase):
                 "season": self.session.season,
                 "year": self.session.year,
                 "families": [
-                    FamilySerializer(self.family, context=context).data,
-                    FamilySerializer(self.other_family, context=context).data,
+                    FamilySerializer(
+                        self.family,
+                        context={
+                            "enrolment": EnrolmentSerializer(self.enrolment).data,
+                        },
+                    ).data,
+                    FamilySerializer(
+                        self.other_family,
+                        context={
+                            "enrolment": EnrolmentSerializer(self.other_enrolment).data
+                        },
+                    ).data,
                 ],
                 "fields": self.session.fields,
                 "classes": [
@@ -143,21 +153,33 @@ class ClassDetailSerializerTestCase(TestCase):
             enrolled_class=self.class1,
         )
 
-    def test_serializer1(self):
+    def test_class_detail_serializer(self):
         self.assertEqual(
             {
                 "id": self.class1.id,
                 "name": self.class1.name,
                 "attendance": self.class1.attendance,
                 "families": [
-                    FamilySerializer(self.family1, context={"request": None}).data,
-                    FamilySerializer(self.family2, context={"request": None}).data,
+                    FamilySerializer(
+                        self.family1,
+                        context={
+                            "request": None,
+                            "enrolment": EnrolmentSerializer(self.enrolment1).data,
+                        },
+                    ).data,
+                    FamilySerializer(
+                        self.family2,
+                        context={
+                            "request": None,
+                            "enrolment": EnrolmentSerializer(self.enrolment2).data,
+                        },
+                    ).data,
                 ],
             },
             ClassDetailSerializer(self.class1, context={"request": None}).data,
         )
 
-    def test_empty_class(self):
+    def test_class_detail_serializer__empty_class(self):
         self.assertEqual(
             {
                 "id": self.empty_class.id,
@@ -243,6 +265,7 @@ class EnrolmentSerializerTestCase(TestCase):
                     "name": self.class2.name,
                 },
                 "status": self.enrolment.status,
+                "students": [],
             },
             EnrolmentSerializer(self.enrolment).data,
         )

--- a/enrolments/tests/views/test_class.py
+++ b/enrolments/tests/views/test_class.py
@@ -1,6 +1,8 @@
 from django.urls import NoReverseMatch, reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.request import Request
+from rest_framework.test import APITestCase, APIRequestFactory
+import json
 
 from accounts.models import User
 from enrolments.models import Class, Session, Enrolment
@@ -54,12 +56,12 @@ class ClassesTestCase(APITestCase):
         url = reverse("class-detail", args=[self.class1.id])
         self.client.force_authenticate(self.user)
         response = self.client.get(url)
-        payload = response.json()
+        context = {'request': Request(APIRequestFactory().get('/'))}
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            payload,
-            ClassDetailSerializer(self.class1).data,
+            response.data,
+            ClassDetailSerializer(self.class1, context=context).data,
         )
 
     def test_method_not_allowed(self):

--- a/enrolments/tests/views/test_class.py
+++ b/enrolments/tests/views/test_class.py
@@ -56,7 +56,7 @@ class ClassesTestCase(APITestCase):
         url = reverse("class-detail", args=[self.class1.id])
         self.client.force_authenticate(self.user)
         response = self.client.get(url)
-        context = {'request': Request(APIRequestFactory().get('/'))}
+        context = {"request": Request(APIRequestFactory().get("/"))}
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(

--- a/enrolments/tests/views/test_class.py
+++ b/enrolments/tests/views/test_class.py
@@ -2,7 +2,6 @@ from django.urls import NoReverseMatch, reverse
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.test import APITestCase, APIRequestFactory
-import json
 
 from accounts.models import User
 from enrolments.models import Class, Session, Enrolment

--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -36,7 +36,7 @@ class FamilySerializer(serializers.HyperlinkedModelSerializer):
     parent = StudentSerializer()
     num_children = SerializerMethodField()
     children = StudentSerializer(many=True)
-    current_enrolment = SerializerMethodField()
+    enrolment = SerializerMethodField()
 
     class Meta:
         model = Family
@@ -49,18 +49,23 @@ class FamilySerializer(serializers.HyperlinkedModelSerializer):
             "preferred_comms",
             "num_children",
             "children",
-            "current_enrolment",
+            "enrolment",
         ]
 
     def get_num_children(self, obj):
         return obj.children.count()
 
-    def get_current_enrolment(self, obj):
-        from enrolments.serializers import EnrolmentSerializer
+    def get_enrolment(self, obj):
+        enrolment = self.context.get("enrolment")
+        if enrolment is not None:
+            return enrolment
 
-        if obj.current_enrolment is None:
-            return None
-        return EnrolmentSerializer(obj.current_enrolment).data
+        if obj.current_enrolment is not None:
+            from enrolments.serializers import EnrolmentSerializer
+
+            return EnrolmentSerializer(obj.current_enrolment).data
+
+        return None
 
 
 class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):

--- a/registration/tests/serializers/test_family.py
+++ b/registration/tests/serializers/test_family.py
@@ -3,6 +3,7 @@ from datetime import date
 
 from registration.models import Family, Student
 from enrolments.models import Enrolment, Session, Class
+from enrolments.tests.utils import utils
 from accounts.models import User
 from registration.serializers import (
     FamilySerializer,
@@ -12,34 +13,24 @@ from enrolments.serializers import EnrolmentSerializer
 
 from datetime import date
 
+context = {"request": None}
+
 
 class FamilySerializerTestCase(TestCase):
     def setUp(self):
-        self.parent1 = Student.objects.create(
+        self.parent = Student.objects.create(
             first_name="Merlin",
             last_name="Fischer",
             role=Student.PARENT,
         )
-        self.parent2 = Student.objects.create(
-            first_name="Gandalf",
-            last_name="Whale",
-            role=Student.PARENT,
-        )
         self.family = Family.objects.create(
-            parent=self.parent2,
+            parent=self.parent,
             email="justkeepswimming@ocean.com",
             cell_number="123456789",
             home_number="1111111111",
             preferred_number="Home",
             address="1 Django Court",
             preferred_comms="Shark Tune",
-        )
-        self.family_without_children = Family.objects.create(
-            parent=self.parent1,
-            email="justkeepswimming@ocean.com",
-            cell_number="123456789",
-            address="42 Wallaby Way",
-            preferred_comms="Whale Song",
         )
         self.child1 = Student.objects.create(
             first_name="Albus",
@@ -54,115 +45,73 @@ class FamilySerializerTestCase(TestCase):
             role=Student.CHILD,
             family=self.family,
         )
-        self.child3 = Student.objects.create(
-            first_name="Harry",
-            last_name="Tuna",
-            role=Student.CHILD,
-            date_of_birth=date(2002, 9, 28),
+
+        self.current_session = Session.objects.create(
+            season="Spring",
+            year=2021,
+            start_date=date(2021, 5, 15),
+        )
+        self.current_class = Class.objects.create(
+            name="Current Class",
+            session=self.current_session,
+            attendance=[],
+        )
+        self.current_enrolment = Enrolment.objects.create(
+            active=True,
+            family=self.family,
+            session=self.current_session,
+            enrolled_class=self.current_class,
         )
 
-    def test_family_number(self):
+        self.past_session = Session.objects.create(
+            season="Fall",
+            year=2019,
+            start_date=date(2019, 1, 23),
+        )
+        self.past_class = Class.objects.create(
+            name="Past Class",
+            session=self.past_session,
+            attendance=[],
+        )
+        self.past_enrolment = Enrolment.objects.create(
+            active=True,
+            family=self.family,
+            session=self.past_session,
+            enrolled_class=self.past_class,
+        )
+
+    def test_family_serializer(self):
         self.assertEqual(
             {
                 "id": self.family.id,
-                "parent": StudentSerializer(
-                    self.family.parent, context={"request": None}
-                ).data,
+                "parent": StudentSerializer(self.family.parent, context=context).data,
                 "email": self.family.email,
                 "phone_number": self.family.home_number,
                 "address": self.family.address,
                 "preferred_comms": self.family.preferred_comms,
                 "num_children": 2,
                 "children": [
-                    StudentSerializer(self.child1, context={"request": None}).data,
-                    StudentSerializer(self.child2, context={"request": None}).data,
+                    StudentSerializer(self.child1, context=context).data,
+                    StudentSerializer(self.child2, context=context).data,
                 ],
-                "current_enrolment": None,
+                "enrolment": EnrolmentSerializer(
+                    self.current_enrolment, context=context
+                ).data,
             },
-            FamilySerializer(self.family, context={"request": None}).data,
+            FamilySerializer(self.family, context=context).data,
         )
 
-    def test_family_status(self):
-        self.parent_with_enrolment = Student.objects.create(
-            first_name="Gollum", last_name="Goat", role=Student.PARENT
-        )
-        self.family_with_multiple_enrolments = Family.objects.create(
-            parent=self.parent_with_enrolment,
-            email="justkeepswimming@ocean.com",
-            cell_number="123456789",
-            address="1 Test Ave",
-            preferred_comms="Dolphin Whistle",
-        )
-        self.facilitator = User.objects.create(email="user@staff.com")
-        self.session1 = Session.objects.create(
-            season="Fall",
-            year=2019,
-            start_date=date(2019, 1, 23),
-        )
-        self.session2 = Session.objects.create(
-            season="Spring",
-            year=2021,
-            start_date=date(2021, 5, 15),
-        )
-        self.class_from_session1 = Class.objects.create(
-            name="Test Class 1",
-            session_id=self.session1.id,
-            facilitator_id=self.facilitator.id,
-            attendance=[],
-        )
-        self.class_from_session2 = Class.objects.create(
-            name="Best Class",
-            session_id=self.session2.id,
-            facilitator_id=self.facilitator.id,
-            attendance=[],
-        )
-        # These ensure that families with multiple enrolments show the correct enrolment status fields
-        self.first_family_enrolment = Enrolment.objects.create(
-            active=False,
-            family=self.family_with_multiple_enrolments,
-            session=self.session1,
-            preferred_class=self.class_from_session1,
-            enrolled_class=self.class_from_session1,
-        )
-        self.second_family_enrolment = Enrolment.objects.create(
-            active=True,
-            family=self.family_with_multiple_enrolments,
-            session=self.session2,
-            preferred_class=self.class_from_session2,
-            enrolled_class=self.class_from_session2,
-            status=Enrolment.REGISTERED,
-        )
+    def test_family_serializer_enrolment__specified(self):
+        data = FamilySerializer(
+            self.family,
+            context={
+                "request": None,
+                "enrolment": EnrolmentSerializer(
+                    self.past_enrolment, context=context
+                ).data,
+            },
+        ).data
         self.assertEqual(
-            {
-                "id": self.family_with_multiple_enrolments.id,
-                "parent": StudentSerializer(
-                    self.family_with_multiple_enrolments.parent,
-                    context={"request": None},
-                ).data,
-                "email": self.family_with_multiple_enrolments.email,
-                "phone_number": self.family_with_multiple_enrolments.cell_number,
-                "address": self.family_with_multiple_enrolments.address,
-                "preferred_comms": self.family_with_multiple_enrolments.preferred_comms,
-                "num_children": 0,
-                "children": [],
-                "current_enrolment": EnrolmentSerializer(
-                    self.second_family_enrolment
-                ).data,
-            },
-            FamilySerializer(
-                self.family_with_multiple_enrolments, context={"request": None}
-            ).data,
+            data.get("enrolment"),
+            EnrolmentSerializer(self.past_enrolment, context=context).data,
         )
-
-    def test_family_serializer_parent(self):
-        data = FamilySerializer(self.family_without_children).data
-        self.assertEqual(data["parent"], StudentSerializer(self.parent1).data)
-        self.assertEqual(data["parent"], StudentSerializer(self.parent1).data)
-
-    def test_family_serializer_children(self):
-        data = FamilySerializer(self.family, context={"request": None}).data
-        self.assertEqual(data.get("num_children"), 2)
-
-    def test_family_serializer_children_none(self):
-        data = FamilySerializer(self.family_without_children).data
-        self.assertEqual(data.get("num_children"), 0)

--- a/registration/tests/serializers/test_family.py
+++ b/registration/tests/serializers/test_family.py
@@ -3,8 +3,6 @@ from datetime import date
 
 from registration.models import Family, Student
 from enrolments.models import Enrolment, Session, Class
-from enrolments.tests.utils import utils
-from accounts.models import User
 from registration.serializers import (
     FamilySerializer,
     StudentSerializer,


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display the enrolled class & status of families in the selected session](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=16114024596844d3b60f80dcc1560a9a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- updated the SessionDetailSerializer and ClassDetailSerializer to pass an enrolment context (for the family's enrolment in that session/class) to the FamilySerializer
  - in the FamilySerializer, if an enrolment was specified, return that in the `enrolment` property
- update tests & clean up some old ones
  - some of the test cases for the family serializer overlapped with one another, so just merged them all into one test case


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. python manage.py test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- code cleanliness

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
