### PR TITLE
Retrieve user name in family interactions

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -10,11 +10,6 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             "id",
             "first_name",
             "last_name",
-            "is_staff",
-            "is_active",
-            "email",
-            "last_login",
-            "date_joined",
         ]
 
 

--- a/accounts/tests/utils/utils.py
+++ b/accounts/tests/utils/utils.py
@@ -4,4 +4,6 @@ from accounts.models import User
 def create_staff_user():
     return User.objects.create(
         email="user@test.com",
+        first_name="Test",
+        last_name="User",
     )

--- a/enrolments/management/commands/load_initial_data.py
+++ b/enrolments/management/commands/load_initial_data.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from faker import Faker
 
+from accounts.models import User
 from enrolments.models import Session, Class, Enrolment
 from registration.models import Family, Student, Field
 import enrolments.tests.utils.utils as enrolment_utils
@@ -57,6 +58,7 @@ class Command(BaseCommand):
                 Field.objects.all().delete()
                 Family.objects.all().delete()
                 Student.objects.all().delete()
+                User.objects.filter(email="user@test.com").delete()
 
                 registration_utils.create_test_fields()
                 staff_user = account_utils.create_staff_user()

--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -5,6 +5,8 @@ from rest_framework.fields import SerializerMethodField
 from .models import Family, Student, Field
 from .validators import validate_student_information_role
 from enrolments.models import Enrolment
+from accounts.models import User
+from accounts.serializers import UserSerializer
 
 
 class StudentSerializer(serializers.HyperlinkedModelSerializer):
@@ -68,6 +70,7 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
     children = StudentSerializer(many=True)
     guests = StudentSerializer(many=True)
     current_enrolment = SerializerMethodField()
+    interactions = serializers.SerializerMethodField()
 
     class Meta:
         model = Family
@@ -95,6 +98,13 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
         if obj.current_enrolment is None:
             return None
         return EnrolmentSerializer(obj.current_enrolment).data
+
+    def get_interactions(self, obj):
+        interactions = obj.interactions
+        for interaction in interactions:
+            user = User.objects.get(id=interaction.pop("user_id"))
+            interaction["user"] = UserSerializer(user).data
+        return interactions
 
     def create(self, validated_data):
         students = validated_data.pop("students")

--- a/registration/tests/serializers/test_family_detail.py
+++ b/registration/tests/serializers/test_family_detail.py
@@ -1,5 +1,6 @@
 from django.test.testcases import TestCase
 
+from accounts.serializers import UserSerializer
 from registration.models import Family, Student
 from accounts.models import User
 from registration.serializers import FamilyDetailSerializer, StudentSerializer
@@ -11,6 +12,8 @@ class FamilyDetailSerializerTestCase(TestCase):
     def setUp(self):
         self.user = User.objects.create(
             email="user@test.com",
+            first_name="Stella",
+            last_name="Pritchett",
         )
         self.family = Family.objects.create(
             email="closets@pritchett.com",
@@ -63,4 +66,17 @@ class FamilyDetailSerializerTestCase(TestCase):
         data = FamilyDetailSerializer(self.family, context=context).data
         self.assertEqual(
             data["guests"], [StudentSerializer(self.guest, context=context).data]
+        )
+
+    def test_family_detail_serializer_interactions(self):
+        data = FamilyDetailSerializer(self.family, context=context).data
+        self.assertEqual(
+            data["interactions"],
+            [
+                {
+                    "type": "Phone Call",
+                    "date": "2012-04-04",
+                    "user": UserSerializer(self.user).data,
+                }
+            ],
         )


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Tracking recent client interactions](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=3ba42ee5d4df4bf4abcc075bb37f93ba)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- overrode `get_interactions` to get the user's first and last name (from the UserSerializer)
- updated load_initial_data to delete test users (was having problems re-running due to duplicate emails)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. python manage.py test
2. python manage.py load_initial_data

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- correctness, test coverage

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
