### PR TITLE
Add "me" endpoint and clean up interaction user data

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,4 +1,7 @@
 from rest_framework import mixins, permissions, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
 from .models import User
 from .serializers import UserSerializer, UserCreateSerializer
 
@@ -6,7 +9,6 @@ from .serializers import UserSerializer, UserCreateSerializer
 class UserViewSet(
     viewsets.GenericViewSet,
     mixins.ListModelMixin,
-    mixins.RetrieveModelMixin,
     mixins.CreateModelMixin,
 ):
     queryset = User.objects.all()
@@ -22,3 +24,13 @@ class UserViewSet(
         if self.action == "create":
             return UserCreateSerializer
         return UserSerializer
+
+    @action(
+        methods=["get"],
+        detail=False,
+        permission_classes=[permissions.IsAuthenticated],
+        url_path="me",
+        url_name="me",
+    )
+    def me(self, request):
+        return Response(UserSerializer(request.user).data)

--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -77,7 +77,6 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
     children = StudentSerializer(many=True)
     guests = StudentSerializer(many=True)
     current_enrolment = SerializerMethodField()
-    interactions = serializers.SerializerMethodField()
 
     class Meta:
         model = Family
@@ -105,13 +104,6 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
         if obj.current_enrolment is None:
             return None
         return EnrolmentSerializer(obj.current_enrolment).data
-
-    def get_interactions(self, obj):
-        interactions = obj.interactions
-        for interaction in interactions:
-            user = User.objects.get(id=interaction.pop("user_id"))
-            interaction["user"] = UserSerializer(user).data
-        return interactions
 
     def create(self, validated_data):
         students = validated_data.pop("students")

--- a/registration/tests/serializers/test_family_detail.py
+++ b/registration/tests/serializers/test_family_detail.py
@@ -21,13 +21,7 @@ class FamilyDetailSerializerTestCase(TestCase):
             preferred_number="Cell",
             address="10 Modern Lane",
             preferred_comms="Phone",
-            interactions=[
-                {
-                    "type": "Phone Call",
-                    "date": "2012-04-04",
-                    "user_id": self.user.id,
-                }
-            ],
+            interactions=[],
         )
         self.parent = Student.objects.create(
             first_name="Claire",
@@ -66,17 +60,4 @@ class FamilyDetailSerializerTestCase(TestCase):
         data = FamilyDetailSerializer(self.family, context=context).data
         self.assertEqual(
             data["guests"], [StudentSerializer(self.guest, context=context).data]
-        )
-
-    def test_family_detail_serializer_interactions(self):
-        data = FamilyDetailSerializer(self.family, context=context).data
-        self.assertEqual(
-            data["interactions"],
-            [
-                {
-                    "type": "Phone Call",
-                    "date": "2012-04-04",
-                    "user": UserSerializer(self.user).data,
-                }
-            ],
         )

--- a/registration/tests/serializers/test_family_detail_update.py
+++ b/registration/tests/serializers/test_family_detail_update.py
@@ -133,7 +133,7 @@ class FamilyDetailSerializerTestCase(TestCase):
 
     def test_family_detail_serializer_update__create_children(self):
         data = dict(self.family_data)
-        new_child = {
+        new_child_data = {
             "id": None,
             "first_name": "Pableaux",
             "last_name": "Petersaune",
@@ -142,7 +142,7 @@ class FamilyDetailSerializerTestCase(TestCase):
             "family": self.family,
             "information": {},
         }
-        data["children"].append(new_child)
+        data["children"].append(new_child_data)
 
         serializer = FamilyDetailSerializer(instance=self.family, data=data)
         self.assertTrue(serializer.is_valid())
@@ -150,13 +150,14 @@ class FamilyDetailSerializerTestCase(TestCase):
         family = serializer.save()
         self.assertEqual(family.children.count(), 3)
 
-        self.assertEqual(family.children[2].first_name, new_child["first_name"])
-        self.assertEqual(family.children[2].last_name, new_child["last_name"])
+        new_child = family.children.order_by("-created_at").first()
+        self.assertEqual(new_child.first_name, new_child_data["first_name"])
+        self.assertEqual(new_child.last_name, new_child_data["last_name"])
         self.assertEqual(
-            family.children[2].date_of_birth.strftime(format="%Y-%m-%d"),
-            new_child["date_of_birth"],
+            new_child.date_of_birth.strftime(format="%Y-%m-%d"),
+            new_child_data["date_of_birth"],
         )
-        self.assertEqual(family.children[2].information, new_child["information"])
+        self.assertEqual(new_child.information, new_child_data["information"])
 
     def test_family_detail_serializer_update__delete_children(self):
         data = dict(self.family_data)


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[add, edit, and delete interactions](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=a74c482b67d34348b4fb59cd2e1a53a3)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- context: the frontend is creating a users context to store the app's users & the current signed in user
  - we no longer need to return extra user data in the family interactions
- added a get "me" endpoint that returns data about the currently authenticated user

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. python manage.py test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- correctness

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
