### PR TITLE
add put field endpoint

### DIFF
--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -3,7 +3,11 @@ from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 
 from .models import Family, Student, Field
-from .validators import validate_student_information_role, validate_field_order
+from .validators import (
+    validate_student_information_role,
+    validate_field_order,
+    validate_field_options,
+)
 from enrolments.serializers import EnrolmentSerializer
 
 
@@ -237,4 +241,5 @@ class FieldSerializer(serializers.HyperlinkedModelSerializer):
         request = self.context.get("request")
         if request.method == "POST":
             validate_field_order(attrs["order"], attrs["role"])
+        validate_field_options(attrs["question_type"], attrs["options"])
         return super().validate(attrs)

--- a/registration/tests/serializers/test_field.py
+++ b/registration/tests/serializers/test_field.py
@@ -50,6 +50,15 @@ class FieldSerializerTestCase(TestCase):
             is_default=True,
             order=1,
         )
+        self.field_request = {
+            "role": Field.PARENT,
+            "name": "Favourite Colour",
+            "question": "What is your favourite colour?",
+            "question_type": Field.TEXT,
+            "is_default": False,
+            "options": [],
+            "order": 3,
+        }
 
     def test_field_list_serializer(self):
         serializer = FieldListSerializer(child=FieldSerializer(), data=Field.objects)
@@ -91,23 +100,31 @@ class FieldSerializerTestCase(TestCase):
         )
 
     def test_field_serializer__order_validator(self):
-        field_request_invalid_order = {
-            "role": Field.PARENT,
-            "name": "Favourite Colour",
-            "question": "What is your favourite colour?",
-            "question_type": "Text",
-            "is_default": False,
-            "options": [],
-            "order": 1,
-        }
+        field_request_invalid_order = self.field_request
         context = {"request": Request(APIRequestFactory().post("/fields/"))}
         serializer = FieldSerializer(data=field_request_invalid_order, context=context)
-        self.assertFalse(serializer.is_valid())
+        self.assertTrue(serializer.is_valid())
 
         field_request_invalid_order["order"] = 4
         serializer = FieldSerializer(data=field_request_invalid_order, context=context)
         self.assertFalse(serializer.is_valid())
 
-        field_request_invalid_order["order"] = 3
+        field_request_invalid_order["order"] = 1
         serializer = FieldSerializer(data=field_request_invalid_order, context=context)
+        self.assertFalse(serializer.is_valid())
+
+    def test_field_serializer__option_validator(self):
+        field_request_invalid_options = self.field_request
+        field_request_invalid_options["question_type"] = Field.SELECT
+
+        context = {"request": Request(APIRequestFactory().post("/fields/"))}
+        serializer = FieldSerializer(
+            data=field_request_invalid_options, context=context
+        )
+        self.assertFalse(serializer.is_valid())
+
+        field_request_invalid_options["options"] = ["Option 1"]
+        serializer = FieldSerializer(
+            data=field_request_invalid_options, context=context
+        )
         self.assertTrue(serializer.is_valid())

--- a/registration/tests/serializers/test_field.py
+++ b/registration/tests/serializers/test_field.py
@@ -117,7 +117,7 @@ class FieldSerializerTestCase(TestCase):
         field_request_invalid_options = self.field_request
         field_request_invalid_options["question_type"] = Field.SELECT
 
-        context = {"request": Request(APIRequestFactory().post("/fields/"))}
+        context = {"request": Request(APIRequestFactory().put("/fields/"))}
         serializer = FieldSerializer(
             data=field_request_invalid_options, context=context
         )

--- a/registration/tests/views/test_field.py
+++ b/registration/tests/views/test_field.py
@@ -87,6 +87,9 @@ class FieldTestCase(APITestCase):
         url = reverse("field-detail", args=[self.parent_field.id])
         self.client.force_authenticate(self.user)
 
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 

--- a/registration/tests/views/test_field.py
+++ b/registration/tests/views/test_field.py
@@ -1,4 +1,4 @@
-from django.urls import NoReverseMatch, reverse
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -35,10 +35,6 @@ class FieldTestCase(APITestCase):
             order=1,
         )
 
-    def test_field_detail_url_fail(self):
-        with self.assertRaises(NoReverseMatch):
-            reverse("field-detail")
-
     def test_get_fields(self):
         url = reverse("field-list")
         self.client.force_authenticate(self.user)
@@ -57,17 +53,45 @@ class FieldTestCase(APITestCase):
         response = self.client.post(
             url,
             {
-                "role": "Child",
+                "role": Field.CHILD,
                 "name": "Favourite Colour",
                 "question": "What is your favourite colour",
-                "question_type": "Text",
+                "question_type": Field.TEXT,
                 "is_default": False,
                 "options": [],
-                "order": Field.objects.filter(role="Child").count() + 1,
+                "order": Field.objects.filter(role=Field.CHILD).count() + 1,
             },
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_put_fields(self):
+        url = reverse("field-detail", args=[self.guest_field.id])
+        self.client.force_authenticate(self.user)
+        response = self.client.put(
+            url,
+            {
+                "role": self.guest_field.role,
+                "name": self.guest_field.name,
+                "question": self.guest_field.question,
+                "question_type": Field.SELECT,
+                "is_default": False,
+                "options": ["Aunt, Uncle, Friend, Other"],
+                "order": Field.objects.filter(role=Field.GUEST).count() + 1,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_method_not_allowed(self):
+        url = reverse("field-detail", args=[self.parent_field.id])
+        self.client.force_authenticate(self.user)
+
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_unauthorized(self):
         url = reverse("field-list")
@@ -76,4 +100,18 @@ class FieldTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        url = reverse("field-detail", args=[self.parent_field.id])
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -79,3 +79,11 @@ def validate_field_order(field_order, role):
         != Field.objects.filter(role=role).aggregate(Max("order"))["order__max"] + 1
     ):
         raise ValidationError("Invalid order value")
+
+
+def validate_field_options(question_type, options):
+    Field = apps.get_model("registration", "Field")
+    if question_type in [Field.SELECT, Field.MULTIPLE_SELECT] and len(options) < 1:
+        raise ValidationError(
+            "Select and multi-select fields must have at least one option"
+        )

--- a/registration/views.py
+++ b/registration/views.py
@@ -57,9 +57,12 @@ class FamilyViewSet(
 
 
 class FieldViewSet(
-    viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateModelMixin
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
 ):
     queryset = Field.objects.all()
     serializer_class = FieldSerializer
-    http_method_names = ["get", "post"]
+    http_method_names = ["get", "post", "put"]
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[PUT field](https://www.notion.so/uwblueprintexecs/PUT-fields-id-endpoint-726ae92328b445c28da6b50385664939)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- add PUT field to viewset
- add validator for field options
- update tests for view and serializer
- validation for changing the field order will come in another PR

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. python manage.py test
2. load initial data and go to localhost:8000/fields/{id} and play around with the endpoint
* you can copy a field object JSON from a GET request to make testing easier

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Testing! Trying to make sure this endpoint works.

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
