### PR TITLE
Update current enrolment logic to be based on whether the session is active

### DIFF
--- a/enrolments/serializers.py
+++ b/enrolments/serializers.py
@@ -140,7 +140,7 @@ class EnrolmentSerializer(serializers.HyperlinkedModelSerializer):
             "status",
             "students",
         ]
-        ordering = ['session__start_date']
+        ordering = ["session__start_date"]
 
     def to_representation(self, instance):
         response = super().to_representation(instance)

--- a/enrolments/serializers.py
+++ b/enrolments/serializers.py
@@ -140,7 +140,6 @@ class EnrolmentSerializer(serializers.HyperlinkedModelSerializer):
             "status",
             "students",
         ]
-        ordering = ["session__start_date"]
 
     def to_representation(self, instance):
         response = super().to_representation(instance)

--- a/enrolments/serializers.py
+++ b/enrolments/serializers.py
@@ -140,6 +140,7 @@ class EnrolmentSerializer(serializers.HyperlinkedModelSerializer):
             "status",
             "students",
         ]
+        ordering = ['session__start_date']
 
     def to_representation(self, instance):
         response = super().to_representation(instance)

--- a/enrolments/tests/views/test_session.py
+++ b/enrolments/tests/views/test_session.py
@@ -29,12 +29,12 @@ class SessionTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # sessions should be ordered by descending start date, with nulls last
+        # sessions should be ordered by ascending start date, with nulls last
         self.assertEqual(
             payload,
             [
-                SessionListSerializer(self.session).data,
                 SessionListSerializer(self.older_session).data,
+                SessionListSerializer(self.session).data,
                 SessionListSerializer(self.session_no_start_date).data,
             ],
         )

--- a/enrolments/views.py
+++ b/enrolments/views.py
@@ -18,7 +18,7 @@ class SessionViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
 ):
-    queryset = Session.objects.all().order_by(F("start_date").desc(nulls_last=True))
+    queryset = Session.objects.all().order_by(F("start_date").asc(nulls_last=True))
     http_method_names = [
         "get",
     ]

--- a/registration/models.py
+++ b/registration/models.py
@@ -68,13 +68,11 @@ class Family(models.Model):
 
     @property
     def current_enrolment(self):
-        most_recent_session = (
-            apps.get_model("enrolments", "Session")
-            .objects.filter(start_date__isnull=False)
-            .order_by("-start_date")
+        return (
+            self.enrolments.filter(session__active=True)
+            .order_by("-session__start_date")
             .first()
         )
-        return self.enrolments.filter(session=most_recent_session).first()
 
     def __str__(self):
         if self.parent is not None:

--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -72,7 +72,7 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
     parent = StudentSerializer()
     children = StudentSerializer(many=True)
     guests = StudentSerializer(many=True)
-    enrolments = EnrolmentSerializer(many=True)
+    enrolments = SerializerMethodField()
 
     class Meta:
         model = Family
@@ -92,6 +92,10 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
             "enrolments",
             "interactions",
         ]
+
+    def get_enrolments(self, obj):
+        enrolments = obj.enrolments.order_by('session__created_at')
+        return EnrolmentSerializer(enrolments, many=True).data
 
     def create(self, validated_data):
         students = validated_data.pop("students")

--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -94,7 +94,7 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
         ]
 
     def get_enrolments(self, obj):
-        enrolments = obj.enrolments.order_by('session__created_at')
+        enrolments = obj.enrolments.order_by("session__created_at")
         return EnrolmentSerializer(enrolments, many=True).data
 
     def create(self, validated_data):

--- a/registration/serializers.py
+++ b/registration/serializers.py
@@ -72,7 +72,6 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
     parent = StudentSerializer()
     children = StudentSerializer(many=True)
     guests = StudentSerializer(many=True)
-    current_enrolment = SerializerMethodField()
     enrolments = EnrolmentSerializer(many=True)
 
     class Meta:
@@ -90,15 +89,9 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
             "children",
             "guests",
             "notes",
-            "current_enrolment",
             "enrolments",
             "interactions",
         ]
-
-    def get_current_enrolment(self, obj):
-        if obj.current_enrolment is None:
-            return None
-        return EnrolmentSerializer(obj.current_enrolment).data
 
     def create(self, validated_data):
         students = validated_data.pop("students")
@@ -114,7 +107,6 @@ class FamilyDetailSerializer(serializers.HyperlinkedModelSerializer):
         return family
 
     def update(self, instance, validated_data):
-        validated_data.pop("current_enrolment")
         validated_data.pop("enrolments")
         students_data = validated_data.pop("students")
         students = (

--- a/registration/tests/serializers/test_family.py
+++ b/registration/tests/serializers/test_family.py
@@ -53,6 +53,7 @@ class FamilySerializerTestCase(TestCase):
         self.current_session = Session.objects.create(
             name="Spring 2021",
             start_date=date(2021, 5, 15),
+            active=True,
         )
         self.current_class = Class.objects.create(
             name="Current Class",

--- a/registration/tests/serializers/test_family_detail_update.py
+++ b/registration/tests/serializers/test_family_detail_update.py
@@ -94,7 +94,6 @@ class FamilyDetailSerializerTestCase(TestCase):
         self.family_data["children"] = self.children_data
         self.family_data["guests"] = self.guests_data
         self.family_data["parent"] = self.parent_data
-        self.family_data["current_enrolment"] = None
         self.family_data["enrolments"] = []
 
     def test_family_detail_serializer_update(self):

--- a/registration/tests/views/test_family.py
+++ b/registration/tests/views/test_family.py
@@ -97,7 +97,6 @@ class FamilyTestCase(APITestCase):
             },
             "children": [],
             "guests": [],
-            "current_enrolment": None,
             "enrolments": [],
         }
         self.parent.family = self.family


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Update logic for current enrolments to be based on whether the session is active](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=0289062affe148dba03c6eba6cd3c3ba)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- see context in the ticket
- updated the logic for the /families endpoint so that the family's `enrolment` is not null if the family is enrolled in a session that is active
- remove `current_enrolment` field in the /families/{id} endpoint → current enrolments will be determined on the frontend based on `enrolments`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. python manage.py test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing the frontend PR to make sure things work

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
