### PR TITLE
Update information validator to allow deleted field IDs

### DIFF
--- a/registration/tests/test_validators.py
+++ b/registration/tests/test_validators.py
@@ -110,7 +110,7 @@ class ValidatorsTestCase(TestCase):
         )
 
     @patch("registration.validators.validate_information_responses")
-    def test_validate_student_information_role__invalid_id(self, mock_validate):
+    def test_validate_student_information_role__deleted_id_ok(self, mock_validate):
         student = {
             "role": Student.PARENT,
             "information": {
@@ -118,13 +118,12 @@ class ValidatorsTestCase(TestCase):
                 "0": "",
             },
         }
-        self.assertRaises(
-            ValidationError,
-            validators.validate_student_information_role,
-            student["information"],
-            student["role"],
+        self.assertIsNone(
+            validators.validate_student_information_role(
+                student["information"],
+                student["role"],
+            )
         )
-        mock_validate.assert_not_called()
 
     @patch("registration.validators.validate_information_responses")
     def test_validate_student_information_role__invalid_role(self, mock_validate):

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -25,10 +25,9 @@ def validate_student_information_role(information, role):
         else:
             valid_roles = [role]
         if (
-            len(information)
-            != Field.objects.filter(
-                id__in=information.keys(), role__in=valid_roles
-            ).count()
+            Field.objects.filter(
+                id__in=information.keys()).exclude(role__in=valid_roles)
+            .count() > 0
         ):
             raise ValidationError(
                 f"One of the provided IDs is not a valid {role} field ID"

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -25,9 +25,10 @@ def validate_student_information_role(information, role):
         else:
             valid_roles = [role]
         if (
-            Field.objects.filter(
-                id__in=information.keys()).exclude(role__in=valid_roles)
-            .count() > 0
+            Field.objects.filter(id__in=information.keys())
+            .exclude(role__in=valid_roles)
+            .count()
+            > 0
         ):
             raise ValidationError(
                 f"One of the provided IDs is not a valid {role} field ID"


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

n/a

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- currently in prod as we're deleting fields, users are unable to save data if their information json contains the deleted field ids
- updates validator logic so we only raise errors if the field ids belong to other roles

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. python manage.py test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- does this make sense?

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
